### PR TITLE
v0.2 - Improved Atom Theming, explored Intellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ This is an alternate branch with slightly different default configs built specif
 
 ## Known Issues
 - Generally speaking, this is **always going to be a work in progress.** I'll do my best to only merge in completed, separate feature branches, but small fixes will be added directly to master from time to time.
+- The current lock screen situation drops the year field sometimes when the date is really long characterwise.
 - `LXAppearance` is not symlink friendly. A wrapper, `dots-lxappearance` is included and PATHed. Use that instead to keep gtk symlinks intact. You shouldn't really need to use it anyway, as the retheme-by-... commands should handle everything.
-- Cursors still aren't fully cooperating with set settings.
+- Cursors might still not fully cooperate with set settings.
 - There's an issue I'm experiencing in the Atom editor on my 4k resolution Virtualbox setup where sections of the window will not render. Don't know what exactly is causing this yet, but a workaround is to either use multiple windows, or to have terminal open in the same workspace.
 
 ## Versioning Rules
@@ -61,19 +62,19 @@ This is an alternate branch with slightly different default configs built specif
  - Minor version number increments indicate the addition of either a complete new feature or a change that requires running `updateDots` to complete the update. **The `0.1` release denotes the initial public posting to reddit.com/r/unixporn.**
  - Patch version number increments indicate any other public commit to `master` that definitely does not require the user to perform any action other than pulling the latest version from GitHub to make active. **The addition of these versioning rules to this documentation constitutes version 0.1.1**
 
-## Roadmap of Definite Upcoming Changes (in priority order)
-1. Better WebDev tools/configurations, such as linters and other utilities.
-2. Weather Widget
-3. Intellij Idea configurations for Java/Scala/Kotlin development, as well as `wal` integration.
-4. `updateDots` optimizations.
-5. Improve Firefox theme handling, automatically handle extensions
-6. Improve Atom and Intellij color themes and Compton config.
+## Roadmap of Upcoming Changes (in priority order)
+1. **[Released Oct. 26, 2018]** Better WebDev tools/configurations, such as linters and other utilities + Improved Atom Theming.
+2. Weather Widget for Polybar
+3. **[On Hold Indefinitely]** Intellij Idea configurations for Java/Scala/Kotlin development, as well as `wal` integration.
+4. `updateDots` optimizations (some of the package managers included will sometimes reinstall already up-to-date packages. Need to stop this.)
+5. Improve Firefox theme handling, automatically handle extensions.
+6. Improve Compton/Dunst configs further, re-explore Intellij color themes.
 7. Explore base switch to straight Arch Linux, Manjaro-Architect, or a completely new flavor entirely.
 8. Prettier bootup process.
 9. Multiple (human) user login setups/login manager
 
-
-
+### Notes regarding roadmap status
+- I attempted looking into the current state of Intellij/wal integrations/alternate Intellij themes, and I was very disappointed. Thus, **this specific pywal integration is indefinitely on hold.** I will still be releasing an update with plugins and more customizations for Intellij, but, for the time being, I'm sticking to their Darcula theme. If anyone wants to try their hand at making pywalled intellij not look bad, I've included my progress thus far in the branch `intellij-pywal`
 
 ## Special Thanks
 I'd like to thank all the Manjaro/Arch Linux maintainers out there, especially [Bernhard Landauer](https://github.com/oberon-manjaro), aka "oberon", the primary maintainer of the Manjaro i3 Community Edition.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is an alternate branch with slightly different default configs built specif
  - Patch version number increments indicate any other public commit to `master` that definitely does not require the user to perform any action other than pulling the latest version from GitHub to make active. **The addition of these versioning rules to this documentation constitutes version 0.1.1**
 
 ## Roadmap of Upcoming Changes (in priority order)
-1. **[Released Oct. 26, 2018]** Better WebDev tools/configurations, such as linters and other utilities + Improved Atom Theming.
+1. **[Released Oct. 25, 2018]** Better WebDev tools/configurations, such as linters and other utilities + Improved Atom Theming.
 2. Weather Widget for Polybar
 3. **[On Hold Indefinitely]** Intellij Idea configurations for Java/Scala/Kotlin development, as well as `wal` integration.
 4. `updateDots` optimizations/refactor installation

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is an alternate branch with slightly different default configs built specif
 1. **[Released Oct. 26, 2018]** Better WebDev tools/configurations, such as linters and other utilities + Improved Atom Theming.
 2. Weather Widget for Polybar
 3. **[On Hold Indefinitely]** Intellij Idea configurations for Java/Scala/Kotlin development, as well as `wal` integration.
-4. `updateDots` optimizations (some of the package managers included will sometimes reinstall already up-to-date packages. Need to stop this.)
+4. `updateDots` optimizations/refactor installation
 5. Improve Firefox theme handling, automatically handle extensions.
 6. Improve Compton/Dunst configs further, re-explore Intellij color themes.
 7. Explore base switch to straight Arch Linux, Manjaro-Architect, or a completely new flavor entirely.

--- a/atom/.atom/packages/frank-syntax/styles/base.less
+++ b/atom/.atom/packages/frank-syntax/styles/base.less
@@ -16,6 +16,10 @@ atom-text-editor {
     color: @syntax-invisible-character-color;
   }
 
+  .line.cursor-line {
+      background-color: @syntax-active-background-color;
+  }
+
   .gutter {
     background-color: @syntax-gutter-background-color;
     color: @syntax-gutter-text-color;

--- a/atom/.atom/packages/frank-syntax/styles/syntax-variables.less
+++ b/atom/.atom/packages/frank-syntax/styles/syntax-variables.less
@@ -14,7 +14,7 @@
 @syntax-gutter-text-color: @light-gray;
 @syntax-gutter-background-color: @very-dark-gray;
 @syntax-gutter-text-color-selected: @very-light-gray;
-@syntax-gutter-background-color-selected: @bg-highlight-gray;
+@syntax-gutter-background-color-selected: @dark-gray;
 
 // Guide colors
 @syntax-wrap-guide-color: @dark-gray;

--- a/atom/.atom/packages/frank-syntax/styles/syntax-variables.less
+++ b/atom/.atom/packages/frank-syntax/styles/syntax-variables.less
@@ -6,8 +6,15 @@
 // General colors
 @syntax-text-color: @foreground;
 @syntax-cursor-color: @foreground;
-@syntax-selection-color: lighten(@dark-gray, 10%);
-@syntax-background-color: @background;
+@syntax-selection-color: @very-light-gray;
+@syntax-background-color: @very-dark-gray;
+@syntax-active-background-color: @bg-highlight-gray;
+
+// Gutter colors
+@syntax-gutter-text-color: @light-gray;
+@syntax-gutter-background-color: @very-dark-gray;
+@syntax-gutter-text-color-selected: @very-light-gray;
+@syntax-gutter-background-color-selected: @bg-highlight-gray;
 
 // Guide colors
 @syntax-wrap-guide-color: @dark-gray;
@@ -17,12 +24,6 @@
 // For find and replace markers
 @syntax-result-marker-color: @light-gray;
 @syntax-result-marker-color-selected: @foreground;
-
-// Gutter colors
-@syntax-gutter-text-color: @very-light-gray;
-@syntax-gutter-text-color-selected: @syntax-gutter-text-color;
-@syntax-gutter-background-color: @dark-gray;
-@syntax-gutter-background-color-selected: @gray;
 
 // For git diff info. i.e. in the gutter
 @syntax-color-renamed: @blue;

--- a/postInstall.sh
+++ b/postInstall.sh
@@ -81,7 +81,6 @@ sudo pacman -Syyu --noconfirm --needed                                          
     mysql-workbench                                                             \
     nodejs                                                                      \
     npm                                                                         \
-    yarn                                                                        \
     atom                                                                        \
     apm	                                                                        \
     git                                                                         \

--- a/postInstall.sh
+++ b/postInstall.sh
@@ -97,7 +97,8 @@ sudo pacman -Syyu --noconfirm --needed                                          
     python-pillow                                                               \
     manjaro-pulse                                                               \
     pavucontrol                                                                 \
-    pa-applet
+    pa-applet                                                                   \
+    intellij-idea-community-edition
 
 #After pacman is finished, take care of other package managers in parallel.
 

--- a/postInstall.sh
+++ b/postInstall.sh
@@ -67,7 +67,7 @@ sed -i 's/-merge /-merge -I /g'     $HOME/.xinitrc
 
 ################################################################################
 #2.) Install Software from repositories
-################################################################################
+##############################################################################
 
 #Install from official repositories...
 sudo pacman -Syyu --noconfirm --needed                                          \
@@ -81,6 +81,7 @@ sudo pacman -Syyu --noconfirm --needed                                          
     mysql-workbench                                                             \
     nodejs                                                                      \
     npm                                                                         \
+    yarn                                                                        \
     atom                                                                        \
     apm	                                                                        \
     git                                                                         \
@@ -103,12 +104,18 @@ sudo pacman -Syyu --noconfirm --needed                                          
 #Atom Editor
 (
 apm install                                                                     \
-    pigments                                                                    \
-    minimap                                                                     \
-    minimap-pigments                                                            \
-    minimap-highlight-selected                                                  \
+    busy-signal                                                                 \
+    highlight-selected                                                          \
+    intentions                                                                  \
     language-ini                                                                \
-    language-terraform
+    language-terraform                                                          \
+    linter                                                                      \
+    linter-eslint                                                               \
+    linter-ui-default                                                           \
+    minimap                                                                     \
+    minimap-highlight-selected                                                  \
+    minimap-pigments                                                            \
+    pigments                                                                    \
 ) &
 
 #Python

--- a/postInstall.sh
+++ b/postInstall.sh
@@ -112,6 +112,7 @@ apm install                                                                     
     language-terraform                                                          \
     linter                                                                      \
     linter-eslint                                                               \
+    linter-gcc                                                                  \
     linter-ui-default                                                           \
     minimap                                                                     \
     minimap-highlight-selected                                                  \

--- a/postInstall.sh
+++ b/postInstall.sh
@@ -100,6 +100,7 @@ sudo pacman -Syyu --noconfirm --needed                                          
     pa-applet
 
 #After pacman is finished, take care of other package managers in parallel.
+
 #Atom Editor
 (
 apm install                                                                     \
@@ -117,7 +118,16 @@ apm install                                                                     
     pigments                                                                    \
 ) &
 
-#Python
+#Nodejs Packages
+#NOTE: if it's useful only in the context of working with web code,
+#it doesn't belong here -- it belongs inside of your projects package.json
+#development dependencies section. Ex: eslint, gulp, yeoman, etc.
+(
+sudo npm install -g                                                             \
+    underscore-cli                                                              \
+) &
+
+#Pip Installs [Python] Packages!
 (
 sudo pip install --upgrade pip
 sudo pip install                                                                \

--- a/scripts/Scripts/retheme.sh
+++ b/scripts/Scripts/retheme.sh
@@ -17,10 +17,6 @@ cp \
     $WALCACHE/colors-atom-syntax \
     $HOME/.atom/packages/frank-syntax/styles/colors.less
 
-# cp \
-#     $WALCACHE/colors-atom-styles.less \
-#     $HOME/.atom/styles.less
-
 #Dunst (notification daemon) Theme
 cp \
     $WALCACHE/colors-dunst \

--- a/scripts/Scripts/retheme.sh
+++ b/scripts/Scripts/retheme.sh
@@ -17,9 +17,9 @@ cp \
     $WALCACHE/colors-atom-syntax \
     $HOME/.atom/packages/frank-syntax/styles/colors.less
 
-cp \
-    $WALCACHE/colors-atom-styles.less \
-    $HOME/.atom/styles.less
+# cp \
+#     $WALCACHE/colors-atom-styles.less \
+#     $HOME/.atom/styles.less
 
 #Dunst (notification daemon) Theme
 cp \

--- a/wal/.config/wal/templates/colors-atom-styles.less
+++ b/wal/.config/wal/templates/colors-atom-styles.less
@@ -1,4 +1,0 @@
-atom-text-editor .gutter {{
-    background-color: {color0};
-    color: {color7};
-}}

--- a/wal/.config/wal/templates/colors-atom-syntax
+++ b/wal/.config/wal/templates/colors-atom-syntax
@@ -1,19 +1,18 @@
 // Note: do NOT commit this file unless YOU, and not a script, made changes to it.
 // It's meant to be edited via automated script whenever the theme is changed.
+@background: {color0};
+@foreground: {color15};
 
-@very-light-gray: #c5c8c6;
-@light-gray: #969896;
-@gray: #373b41;
-@dark-gray: #282a2e;
-@very-dark-gray: #1d1f21;
+@very-dark-gray: @background;
+@dark-gray: lighten(@background, 15%);
+@gray: lighten(@background, 30%);
+@light-gray: lighten(@background, 45%);
+@very-light-gray: lighten(@background, 60%);
 
 @red: {color1};
 @green: {color2};
-@light-orange: {color8};
 @orange: {color3};
+@light-orange: lighten(@orange, 15%);
 @blue: {color4};
 @purple: {color5};
 @cyan: {color6};
-
-@background: {color0};
-@foreground: {color15};

--- a/wal/.config/wal/templates/colors-atom-syntax
+++ b/wal/.config/wal/templates/colors-atom-syntax
@@ -4,6 +4,7 @@
 @foreground: {color15};
 
 @very-dark-gray: @background;
+@bg-highlight-gray: lighten(@background, 5%);
 @dark-gray: lighten(@background, 15%);
 @gray: lighten(@background, 30%);
 @light-gray: lighten(@background, 45%);
@@ -11,8 +12,8 @@
 
 @red: {color1};
 @green: {color2};
-@orange: {color3};
-@light-orange: lighten(@orange, 15%);
+@light-orange: {color3};
+@orange: darken(@light-orange, 20%);
 @blue: {color4};
 @purple: {color5};
 @cyan: {color6};


### PR DESCRIPTION
- Changed what colors are used in certain situations in our pywal-powered Atom theme in order to prevent certain elements from being washed out by more dominant colors. Also added more linting plugins by default.

- Added Intellij Idea Install

- Added underscore-cli, a very good utility for bringing javascript to BASH, which can simplify a few things in some scripts. Also great for pretty printing JSON.

- Switched NPM for Yarn, yet promptly switched back once I realized how crap Yarn is now given recent improvements to NPM.

Note: decided to walk back on integrating intellij with pywal for now, given the current state of the process involved.